### PR TITLE
gorequest wasn't sending the request for validation

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -97,7 +97,7 @@ func NewWithConfig(config Config) Client {
 }
 
 // Verify sends receipts and gets validation result
-func (c *Client) Verify(req *IAPRequest) (IAPResponse, error) {
+func (c *Client) Verify(req IAPRequest) (IAPResponse, error) {
 	result := IAPResponse{}
 	res, body, errs := gorequest.New().
 		Post(c.URL).

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -99,15 +99,9 @@ func NewWithConfig(config Config) Client {
 // Verify sends receipts and gets validation result
 func (c *Client) Verify(req *IAPRequest) (IAPResponse, error) {
 	result := IAPResponse{}
-	obj, err_json := json.Marshal(req)
-	if err_json != nil {
-		return result, fmt.Errorf("%v", err_json)
-	}
-
 	res, body, errs := gorequest.New().
 		Post(c.URL).
-		Type("json").
-		SendString(string(obj)).
+		Send(req).
 		Timeout(c.TimeOut).
 		End()
 

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -105,7 +105,7 @@ func TestVerify(t *testing.T) {
 	req := IAPRequest{
 		ReceiptData: "dummy data",
 	}
-	actual, _ := client.Verify(&req)
+	actual, _ := client.Verify(req)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("got %v\nwant %v", actual, expected)
 	}


### PR DESCRIPTION
In the gorequest Send method, there is a switch that checks the type of the parameter (https://github.com/parnurzeal/gorequest/blob/master/main.go#L341). In this particular case, the type of *IAPRequest is "ptr" which results in gorequest's switch to go the default case which is empty. The request was made with an empty body.