### PR TITLE
Add Support for the Amazon Receipt Verification Service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: setup cover
 
 setup:
-		go get code.google.com/p/go.tools/cmd/cover
+		go get golang.org/x/tools/cmd/cover
 		go get ./...
 
 test:
@@ -15,4 +15,3 @@ cover:
 		go test -v -coverprofile=playstore.txt -covermode=count ./playstore
 		cat playstore.txt | grep -v "mode: count" >> coverage.txt
 		rm playstore.txt
-

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Current API Documents:
 * AppStore: [![GoDoc](https://godoc.org/github.com/dogenzaka/go-iap/appstore?status.svg)](https://godoc.org/github.com/dogenzaka/go-iap/appstore)
 * GooglePlay: [![GoDoc](https://godoc.org/github.com/dogenzaka/go-iap/playstore?status.svg)](https://godoc.org/github.com/dogenzaka/go-iap/playstore)
 
+* Amazon AppStore: [![GoDoc](https://godoc.org/github.com/dogenzaka/go-iap/amazon?status.svg)](https://godoc.org/github.com/dogenzaka/go-iap/amazon)
+
+
 # Dependencies
 ```
 go get github.com/parnurzeal/gorequest


### PR DESCRIPTION
This adds an amazon package which adds support for [RVS for IAP v2.0](https://developer.amazon.com/public/apis/earn/in-app-purchasing/docs-v2/verifying-receipts-in-iap-2.0)