### PR TITLE
Update IAPClient.Verify to use interface argument

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -24,7 +24,7 @@ type Config struct {
 
 // IAPClient is an interface to call validation API in App Store
 type IAPClient interface {
-	Verify(IAPRequest) (IAPResponse, error)
+	Verify(IAPRequest, interface{}) error
 }
 
 // Client implements IAPClient


### PR DESCRIPTION
Interface IAPClient and its implementation Client no longer match since the updates to Client in https://github.com/dogenzaka/go-iap/commit/e9d5da1f8f6bff09e3f0ff777a44fe617e45ae52