### PR TITLE
Use standard context package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Current API Documents:
 
 # Dependencies
 ```
-go get golang.org/x/net/context
 go get golang.org/x/oauth2
 go get golang.org/x/oauth2/google
 go get google.golang.org/api/androidpublisher/v2

--- a/playstore/validator.go
+++ b/playstore/validator.go
@@ -1,6 +1,7 @@
 package playstore
 
 import (
+	"context"
 	"crypto"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -10,7 +11,6 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	androidpublisher "google.golang.org/api/androidpublisher/v2"


### PR DESCRIPTION
Context is now a Standard Go library.
So I replace golang.org/x/net/context with it.