### PR TITLE
Add TryBothStores config option

### DIFF
--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -91,7 +91,7 @@ func TestHandleError(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := Client{
-		URL:     "https://sandbox.itunes.apple.com/verifyReceipt",
+		URL:     SandboxURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -103,7 +103,7 @@ func TestNew(t *testing.T) {
 
 func TestNewWithEnvironment(t *testing.T) {
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -123,7 +123,7 @@ func TestNewWithConfig(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 2,
 	}
 
@@ -139,8 +139,25 @@ func TestNewWithConfigTimeout(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
+	}
+
+	actual := NewWithConfig(config)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("got %v\nwant %v", actual, expected)
+	}
+}
+
+func TestNewWithConfigTryBothStores(t *testing.T) {
+	config := Config{
+		TryBothStores: true,
+	}
+
+	expected := Client{
+		URL:           ProductionURL,
+		TimeOut:       time.Second * 5,
+		TryBothStores: true,
 	}
 
 	actual := NewWithConfig(config)


### PR DESCRIPTION
Call Production App Store First. Then call sandbox. We're currently
doing this outside of the library which isn't ideal.
https://developer.apple.com/library/content/technotes/tn2259/_index.html

How do I verify my receipt (iOS)?

Always verify your receipt first with the production URL; proceed to
verify with the sandbox URL if you receive a 21007 status code.
Following this approach ensures that you do not have to switch between
URLs while your application is being tested or reviewed in the sandbox
or is live in the App Store.

PLAT-6523