### PR TITLE
Have app store hit prod and then sandbox if 21007

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -129,7 +129,7 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 	// a 21007 status code
 	//
 	// https://developer.apple.com/library/content/technotes/tn2413/_index.html#//apple_ref/doc/uid/DTS40016228-CH1-RECEIPTURL
-	r, ok := result.(IAPResponse)
+	r, ok := result.(*IAPResponse)
 	if ok && r.Status == 21007 {
 		resp, err := client.Post(SandboxURL, "application/json; charset=utf-8", b)
 		if err != nil {

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -121,6 +121,24 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 	defer resp.Body.Close()
 
 	err = json.NewDecoder(resp.Body).Decode(result)
+	if err != nil {
+		return err
+	}
 
-	return err
+	// Always verify your receipt first with the production URL; proceed to verify with the sandbox URL if you receive
+	// a 21007 status code
+	//
+	// https://developer.apple.com/library/content/technotes/tn2413/_index.html#//apple_ref/doc/uid/DTS40016228-CH1-RECEIPTURL
+	r, ok := result.(IAPResponse)
+	if ok && r.Status == 21007 {
+		resp, err := client.Post(SandboxURL, "application/json; charset=utf-8", b)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+
+	return nil
 }

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -131,6 +131,8 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 	// https://developer.apple.com/library/content/technotes/tn2413/_index.html#//apple_ref/doc/uid/DTS40016228-CH1-RECEIPTURL
 	r, ok := result.(*IAPResponse)
 	if ok && r.Status == 21007 {
+		b = new(bytes.Buffer)
+		json.NewEncoder(b).Encode(req)
 		resp, err := client.Post(SandboxURL, "application/json; charset=utf-8", b)
 		if err != nil {
 			return err

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -91,7 +91,7 @@ func TestHandleError(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := Client{
-		URL:     "https://sandbox.itunes.apple.com/verifyReceipt",
+		URL:     SandboxURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -103,7 +103,7 @@ func TestNew(t *testing.T) {
 
 func TestNewWithEnvironment(t *testing.T) {
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -123,7 +123,7 @@ func TestNewWithConfig(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 2,
 	}
 
@@ -139,7 +139,7 @@ func TestNewWithConfigTimeout(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
 	}
 


### PR DESCRIPTION
According to https://developer.apple.com/library/content/technotes/tn2413/_index.html#//apple_ref/doc/uid/DTS40016228-CH1-RECEIPTURL

```
Always verify your receipt first with the production URL; proceed to verify with the sandbox URL if you receive a 21007 status code. Following this approach ensures that you do not have to switch between URLs while your application is being tested or reviewed in the sandbox or is live in the App Store.
```